### PR TITLE
4 fr progress tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
 	"name": "writing-goals",
-	"version": "0.4.2",
+	"version": "0.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "writing-goals",
-			"version": "0.4.2",
+			"version": "0.5.1",
 			"dependencies": {
 				"@rollup/plugin-commonjs": "^25.0.4",
 				"@rollup/plugin-node-resolve": "^15.2.1",
-				"remove-markdown": "^0.5.0"
+				"remove-markdown": "^0.5.0",
+				"svelte-heatmap": "^1.0.2",
+				"svelte-tiny-linked-charts": "^1.4.1"
 			},
 			"devDependencies": {
 				"@rollup/plugin-typescript": "^11.1.2",
@@ -34,7 +36,6 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
 			"integrity": "sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.0",
 				"@jridgewell/trace-mapping": "^0.3.9"
@@ -418,7 +419,6 @@
 			"version": "0.3.3",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/set-array": "^1.0.1",
 				"@jridgewell/sourcemap-codec": "^1.4.10",
@@ -432,7 +432,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
 			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -441,7 +440,6 @@
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
-			"dev": true,
 			"engines": {
 				"node": ">=6.0.0"
 			}
@@ -455,7 +453,6 @@
 			"version": "0.3.19",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
 			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
 				"@jridgewell/sourcemap-codec": "^1.4.14"
@@ -785,7 +782,6 @@
 			"version": "8.10.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
 			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -810,7 +806,6 @@
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
 			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -828,7 +823,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
 			"integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
-			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.3"
 			}
@@ -939,7 +933,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
 			"integrity": "sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15",
 				"@types/estree": "^1.0.1",
@@ -952,7 +945,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -987,7 +979,6 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
 			"integrity": "sha512-6Fv1DV/TYw//QF5IzQdqsNDjx/wc8TrMBZsqjL9eW01tWb7R7k/mq+/VXfJCl7SoD5emsJop9cOByJZfs8hYIw==",
-			"dev": true,
 			"dependencies": {
 				"mdn-data": "2.0.30",
 				"source-map-js": "^1.0.1"
@@ -1025,7 +1016,6 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
 			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1471,8 +1461,7 @@
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
 		},
 		"node_modules/magic-string": {
 			"version": "0.27.0",
@@ -1488,8 +1477,7 @@
 		"node_modules/mdn-data": {
 			"version": "2.0.30",
 			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.30.tgz",
-			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA==",
-			"dev": true
+			"integrity": "sha512-GaqWWShW4kv/G9IEucWScBx9G1/vsFZZJUO+tD26M8J8z3Kw5RDQjaoZe03YAClgeS/SWPOcb4nkFBTEi5DUEA=="
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
@@ -1687,7 +1675,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
 			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
@@ -1698,7 +1685,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -1707,7 +1693,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
 			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -2049,7 +2034,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
 			"integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -2097,7 +2081,6 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.0.tgz",
 			"integrity": "sha512-kVsdPjDbLrv74SmLSUzAsBGquMs4MPgWGkGLpH+PjOYnFOziAvENVzgJmyOCV2gntxE32aNm8/sqNKD6LbIpeQ==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.1",
 				"@jridgewell/sourcemap-codec": "^1.4.15",
@@ -2138,6 +2121,11 @@
 			"peerDependencies": {
 				"svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0"
 			}
+		},
+		"node_modules/svelte-heatmap": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/svelte-heatmap/-/svelte-heatmap-1.0.2.tgz",
+			"integrity": "sha512-qVsJj/Y/FQCjYJ2A7QU/v87FjGFjWqrTIb+qPumrudzH5w6D5WoubHF7Q2g38naJry4ADO1I0K29UuC86t5lJw=="
 		},
 		"node_modules/svelte-hmr": {
 			"version": "0.15.3",
@@ -2213,11 +2201,18 @@
 				}
 			}
 		},
+		"node_modules/svelte-tiny-linked-charts": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/svelte-tiny-linked-charts/-/svelte-tiny-linked-charts-1.4.1.tgz",
+			"integrity": "sha512-V+ykjeBPZMdN0oqdLyIuKiwSRDf2t2rut+H3u5olip8HdYHVAxANyw+3gcjVkD0KgWdoB37N2j78Rf7m7ZZ+NA==",
+			"peerDependencies": {
+				"svelte": "^4.0.0"
+			}
+		},
 		"node_modules/svelte/node_modules/estree-walker": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
 			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.0"
 			}
@@ -2226,7 +2221,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
 			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -2235,7 +2229,6 @@
 			"version": "0.30.3",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.3.tgz",
 			"integrity": "sha512-B7xGbll2fG/VjP+SWg4sX3JynwIU0mjoTc6MPpKNuIvftk6u6vqhDnk1R80b8C2GBR6ywqy+1DcKBrevBg+bmw==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "writing-goals",
-	"version": "0.5.1",
+	"version": "0.5.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "writing-goals",
-			"version": "0.5.1",
+			"version": "0.5.3",
 			"dependencies": {
 				"@rollup/plugin-commonjs": "^25.0.4",
 				"@rollup/plugin-node-resolve": "^15.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
 				"@rollup/plugin-commonjs": "^25.0.4",
 				"@rollup/plugin-node-resolve": "^15.2.1",
 				"remove-markdown": "^0.5.0",
-				"svelte-heatmap": "^1.0.2",
 				"svelte-tiny-linked-charts": "^1.4.1"
 			},
 			"devDependencies": {
@@ -2121,11 +2120,6 @@
 			"peerDependencies": {
 				"svelte": "^3.55.0 || ^4.0.0-next.0 || ^4.0.0"
 			}
-		},
-		"node_modules/svelte-heatmap": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/svelte-heatmap/-/svelte-heatmap-1.0.2.tgz",
-			"integrity": "sha512-qVsJj/Y/FQCjYJ2A7QU/v87FjGFjWqrTIb+qPumrudzH5w6D5WoubHF7Q2g38naJry4ADO1I0K29UuC86t5lJw=="
 		},
 		"node_modules/svelte-hmr": {
 			"version": "0.15.3",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"@rollup/plugin-commonjs": "^25.0.4",
 		"@rollup/plugin-node-resolve": "^15.2.1",
 		"remove-markdown": "^0.5.0",
-		"svelte-heatmap": "^1.0.2",
 		"svelte-tiny-linked-charts": "^1.4.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
 	"dependencies": {
 		"@rollup/plugin-commonjs": "^25.0.4",
 		"@rollup/plugin-node-resolve": "^15.2.1",
-		"remove-markdown": "^0.5.0"
+		"remove-markdown": "^0.5.0",
+		"svelte-heatmap": "^1.0.2",
+		"svelte-tiny-linked-charts": "^1.4.1"
 	}
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ export const DAILY_GOAL_FRONTMATTER_KEY = "daily-word-goal";
 export const WORD_COUNT_INCLUDE_FRONTMATTER_KEY = "wordcount";
 export const VIEW_TYPE_GOAL = "writing-goal";
 export const VIEW_TYPE_GOAL_SIMPLE = "writing-goal-simple";
+export const VIEW_TYPE_STATS = "writing-goal-stats";
 export const VIEW_TYPE_FILE_EXPLORER = "file-explorer"
 export const GOAL_ICON = "lucide-loader-2";
 export const REMOVE_GOAL_ICON = "lucide-x";

--- a/src/goal-history/history.ts
+++ b/src/goal-history/history.ts
@@ -108,7 +108,11 @@ export class GoalHistoryHelper {
         return datesData;
     }
 
-
+    async getLinkedChartData(path:string){
+        const heatmapData = await this.getStats(path);
+        const result = Object.fromEntries(heatmapData.filter(d => d.value > 0).map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.value]));
+        return result;
+    }
 }
 
 export class HistoryStatsItem{

--- a/src/goal-history/history.ts
+++ b/src/goal-history/history.ts
@@ -92,4 +92,28 @@ export class GoalHistoryHelper {
     async historyExists() {
         return await this.goalFile.exists(GOAL_HISTORY_PATH);
     }
+
+    async getStats() {
+        const history = await this.loadHistory();
+        let datesData = [];
+        for(let path in history){
+            const item = history[path];
+            const dateCounts = item.map((i) => new HistoryStatsItem(i.date, i.endCount - i.startCount));
+            datesData.push(...dateCounts);
+        }
+        datesData = datesData.sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
+        return datesData;
+    }
+
+
+}
+
+export class HistoryStatsItem{
+    date: string;
+    value: number;
+
+    constructor(date:string, value:number) {
+        this.date = date;
+        this.value = value;
+    }
 }

--- a/src/goal-history/history.ts
+++ b/src/goal-history/history.ts
@@ -93,11 +93,14 @@ export class GoalHistoryHelper {
         return await this.goalFile.exists(GOAL_HISTORY_PATH);
     }
 
-    async getStats() {
+    async getStats(path?:string) {
         const history = await this.loadHistory();
         let datesData = [];
-        for(let path in history){
-            const item = history[path];
+        for(let historyPath in history){
+            if(path != null && path != historyPath){
+                continue;
+            }
+            const item = history[historyPath];
             const dateCounts = item.map((i) => new HistoryStatsItem(i.date, i.endCount - i.startCount));
             datesData.push(...dateCounts);
         }

--- a/src/goal-history/history.ts
+++ b/src/goal-history/history.ts
@@ -67,12 +67,12 @@ export class GoalHistoryHelper {
     }
 
     async saveGoal(path:string, item:GoalHistoryItem) {
-        const goalHistory = await this.loadHistory();
-        let historyForPath = goalHistory[path] ?? [];
+        const history = await this.loadHistory();
+        let historyForPath = history[path] ?? [];
         historyForPath = historyForPath.filter(ghi => ghi.date != item.date);
         historyForPath.push(item);
-        goalHistory[path] = historyForPath;
-        await this.goalFile.saveJson(GOAL_HISTORY_PATH, goalHistory);
+        history[path] = historyForPath;
+        await this.goalFile.saveJson(GOAL_HISTORY_PATH, history);
     }
 
     async resetDailyProgress(path: string) {
@@ -97,12 +97,11 @@ export class GoalHistoryHelper {
         const history = await this.loadHistory();
         let datesData = [];
         for(let historyPath in history){
-            if(path != null && path != historyPath){
-                continue;
+            if(path == null || path == historyPath){
+                const item = history[historyPath];
+                const dateCounts = item.map((i) => new HistoryStatsItem(i.date, i.endCount - i.startCount));
+                datesData.push(...dateCounts);
             }
-            const item = history[historyPath];
-            const dateCounts = item.map((i) => new HistoryStatsItem(i.date, i.endCount - i.startCount));
-            datesData.push(...dateCounts);
         }
         datesData = datesData.sort((a, b) => new Date(a).getTime() - new Date(b).getTime());
         return datesData;
@@ -110,8 +109,14 @@ export class GoalHistoryHelper {
 
     async getLinkedChartData(path:string){
         const heatmapData = await this.getStats(path);
-        const result = Object.fromEntries(heatmapData.filter(d => d.value > 0).map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.value]));
+        console.log('transform input', heatmapData);
+        const result = this.transformChartData(heatmapData);
+        console.log('transform result', result);
         return result;
+    }
+
+    transformChartData(data: any[]) {
+        return Object.fromEntries(data.map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.value]));
     }
 }
 

--- a/src/goal/goal-summary.svelte
+++ b/src/goal/goal-summary.svelte
@@ -6,8 +6,8 @@
     export let goal: NoteGoal;
     export let percent: number;
     export let dailyPercent: number;
-    export let gColor: string;
-    export let dGColor: string;
+    export let color: string;
+    export let dailyColor: string;
 
     let showMessage: boolean = true;
 
@@ -37,7 +37,7 @@
         {#if dailyPercent >= 100}
         {goal.dailyGoalCount.toLocaleString()} <span class="note-daily-goal note-goal-completed">daily word goal</span> completed!
         {:else}
-        {goal.dailyGoalCount.toLocaleString()} <span class="note-daily-goal" style="{getColorStyle(dGColor)}">daily word goal</span>
+        {goal.dailyGoalCount.toLocaleString()} <span class="note-daily-goal" style="{getColorStyle(dailyColor)}">daily word goal</span>
         {/if}
     </h3>
     {/if}
@@ -46,7 +46,7 @@
         {#if percent >= 100}
             {goal.goalCount.toLocaleString()} <span class="note-goal note-goal-completed">word goal completed!</span>
         {:else}
-            {getOverallGoalCountText(goal)} {goal.goalCount.toLocaleString()}&nbsp;<span class="note-goal" style="{getColorStyle(gColor)}">word goal</span> 
+            {getOverallGoalCountText(goal)} {goal.goalCount.toLocaleString()}&nbsp;<span class="note-goal" style="{getColorStyle(color)}">word goal</span> 
         {/if}
         </h3>
     {/if}

--- a/src/goal/goal-summary.svelte
+++ b/src/goal/goal-summary.svelte
@@ -32,23 +32,23 @@
 </style>
 
 {#if showMessage}
-    {#if goal.dailyGoalCount > 0}
-    <h3>
-        {#if dailyPercent >= 100}
-        {goal.dailyGoalCount.toLocaleString()} <span class="note-daily-goal note-goal-completed">daily word goal</span> completed!
-        {:else}
-        {goal.dailyGoalCount.toLocaleString()} <span class="note-daily-goal" style="{getColorStyle(dailyColor)}">daily word goal</span>
-        {/if}
-    </h3>
-    {/if}
     {#if goal.goalCount > 0}
-        <h3>
+    <h3>
         {#if percent >= 100}
             {goal.goalCount.toLocaleString()} <span class="note-goal note-goal-completed">word goal completed!</span>
         {:else}
             {getOverallGoalCountText(goal)} {goal.goalCount.toLocaleString()}&nbsp;<span class="note-goal" style="{getColorStyle(color)}">word goal</span> 
         {/if}
-        </h3>
+    </h3>
+    {/if}
+    {#if goal.dailyGoalCount > 0}
+    <h3>
+        {#if dailyPercent >= 100}
+            {goal.dailyGoalCount.toLocaleString()} <span class="note-daily-goal note-goal-completed">daily word goal</span> completed!
+        {:else}
+            {goal.dailyGoalCount.toLocaleString()} <span class="note-daily-goal" style="{getColorStyle(dailyColor)}">daily word goal</span>
+        {/if}
+    </h3>
     {/if}
 {/if}
 

--- a/src/goal/goal-view.ts
+++ b/src/goal/goal-view.ts
@@ -7,6 +7,7 @@ import type WritingGoals from '../main';
 import GoalModal from '../modals/goal-modal';
 import type { GoalHistoryHelper, HistoryStatsItem } from '../goal-history/history';
 import moment from 'moment';
+import { noteGoals } from '../stores/goal-store';
 
 
 export default class GoalView extends ItemView {
@@ -17,6 +18,7 @@ export default class GoalView extends ItemView {
     plugin: WritingGoals;
     goal: any;
     historyHelper: GoalHistoryHelper;
+    linkedListData: { [k: string]: number; };
 
     constructor(leaf: WorkspaceLeaf, plugin: WritingGoals, historyHelper:GoalHistoryHelper){
         super(leaf);
@@ -64,14 +66,9 @@ export default class GoalView extends ItemView {
 
     }
 
-    getLinkedChartData(data: HistoryStatsItem[]){
-        const result = Object.fromEntries(data.filter(d => d.value > 0).map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.value]));
-        return result;
-    }
-
     async setGoal() {
-        const heatmapData = await this.historyHelper.getStats(this.path);
-        const linkedListData = this.getLinkedChartData(heatmapData);
+    
+        const linkedChartData = await this.historyHelper.getLinkedChartData(this.path);
         const customGoalBarColor = this.plugin.settings.customGoalBarColor;
         const customDailyGoalBarColor = this.plugin.settings.customDailyGoalBarColor;
 
@@ -88,8 +85,7 @@ export default class GoalView extends ItemView {
                 mode: 'full',
                 color: customGoalBarColor,
                 dailyColor: customDailyGoalBarColor,
-                heatmapData: heatmapData,
-                linkedChartData: linkedListData,
+                linkedChartData: linkedChartData,
                 rootEl: this.containerEl
             },
         });    

--- a/src/goal/goal-view.ts
+++ b/src/goal/goal-view.ts
@@ -70,14 +70,16 @@ export default class GoalView extends ItemView {
     }
 
     async setGoal() {
-        if(this.goal != null) {
-            console.log('destroying goal view');
-            this.goal.$destroy();
-        }
         const heatmapData = await this.historyHelper.getStats(this.path);
         const linkedListData = this.getLinkedChartData(heatmapData);
         const customGoalBarColor = this.plugin.settings.customGoalBarColor;
         const customDailyGoalBarColor = this.plugin.settings.customDailyGoalBarColor;
+
+        //Goal svelte componet creation must happen immediately after existing component is destroyed.
+        if(this.goal != null) {
+            console.log('destroying goal view');
+            this.goal.$destroy();
+        }
         this.goal = new Goal({
             target: (this as any).contentEl,
             props: {

--- a/src/goal/goal-view.ts
+++ b/src/goal/goal-view.ts
@@ -77,7 +77,6 @@ export default class GoalView extends ItemView {
 
         //Goal svelte componet creation must happen immediately after existing component is destroyed.
         if(this.goal != null) {
-            console.log('destroying goal view');
             this.goal.$destroy();
         }
         this.goal = new Goal({

--- a/src/goal/goal-view.ts
+++ b/src/goal/goal-view.ts
@@ -5,7 +5,8 @@ import { GOAL_ICON, VIEW_TYPE_GOAL } from '../constants';
 import { ObsidianFileHelper } from '../IO/obsidian-file';
 import type WritingGoals from '../main';
 import GoalModal from '../modals/goal-modal';
-import type { GoalHistoryHelper } from '../goal-history/history';
+import type { GoalHistoryHelper, HistoryStatsItem } from '../goal-history/history';
+import moment from 'moment';
 
 
 export default class GoalView extends ItemView {
@@ -15,11 +16,13 @@ export default class GoalView extends ItemView {
     path:string;
     plugin: WritingGoals;
     goal: any;
+    historyHelper: GoalHistoryHelper;
 
-    constructor(leaf: WorkspaceLeaf, plugin: WritingGoals){
+    constructor(leaf: WorkspaceLeaf, plugin: WritingGoals, historyHelper:GoalHistoryHelper){
         super(leaf);
         this.plugin = plugin;
         this.fileHelper = new ObsidianFileHelper(this.plugin.settings);
+        this.historyHelper = historyHelper;
     }
 
     getViewType(): string {
@@ -34,7 +37,7 @@ export default class GoalView extends ItemView {
         return GOAL_ICON;
     }
     
-    onload(): void {
+    async onload(): Promise<void> {
         if(this.goal != undefined){
             return;
         }
@@ -43,28 +46,38 @@ export default class GoalView extends ItemView {
             return;
         }
         this.path = path; 
-        this.setGoal();
+        await this.setGoal();
     }
 
     async onOpen() {
-        this.setGoal();
+        await this.setGoal();
     }
 
     async updatePath(path:string) {
         this.plugin.settings.goalLeaves.push(path);
         this.plugin.saveData(this.plugin.settings);
         this.path = path;
-        this.setGoal();
+        await this.setGoal();
     }
 
     async onClose() {
 
     }
 
-    setGoal() {
+    getLinkedChartData(data: HistoryStatsItem[]){
+        const result = Object.fromEntries(data.filter(d => d.value > 0).map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.value]));
+        return result;
+    }
+
+    async setGoal() {
         if(this.goal != null) {
+            console.log('destroying goal view');
             this.goal.$destroy();
         }
+        const heatmapData = await this.historyHelper.getStats(this.path);
+        const linkedListData = this.getLinkedChartData(heatmapData);
+        const customGoalBarColor = this.plugin.settings.customGoalBarColor;
+        const customDailyGoalBarColor = this.plugin.settings.customDailyGoalBarColor;
         this.goal = new Goal({
             target: (this as any).contentEl,
             props: {
@@ -72,8 +85,10 @@ export default class GoalView extends ItemView {
                 app: this.app,
                 path: this.path,
                 mode: 'full',
-                color: this.plugin.settings.customGoalBarColor,
-                dailyColor: this.plugin.settings.customDailyGoalBarColor,
+                color: customGoalBarColor,
+                dailyColor: customDailyGoalBarColor,
+                heatmapData: heatmapData,
+                linkedChartData: linkedListData,
                 rootEl: this.containerEl
             },
         });    

--- a/src/goal/goal.svelte
+++ b/src/goal/goal.svelte
@@ -2,18 +2,16 @@
     import  GoalSummary from './goal-summary.svelte';
     import  Stats from '../stats/stats.svelte';
     import { onDestroy, onMount } from "svelte";
-	  import { dailyGoalColor, goalColor, noteGoals, showGoalMessage } from '../stores/goal-store';
+	  import { dailyGoalColor, goalColor, goalHistory, noteGoals, showGoalMessage } from '../stores/goal-store';
 	  import type { NoteGoal, Notes } from '../note-goal';
 	  import type { App } from 'obsidian';
 	  import type WritingGoals from '../main';
-	  import type { HistoryStatsItem } from '../goal-history/history';
     export let mode: string;
     export let path: string;
     export let color: string;
     export let dailyColor: string;
     export let plugin: WritingGoals;
     export let app: App;
-    export let heatMapData: HistoryStatsItem[];
     export let linkedChartData: any;
 
     let statsChildRef;
@@ -44,7 +42,6 @@
         progress = calculateProgress(90, percent);
         dailyProgress = calculateProgress(75, dailyPercent);
         simpleDailyProgress = calculateProgress(50, dailyPercent);
-
     });
 
     const unsubGoalColor = goalColor.subscribe(val => {
@@ -150,10 +147,9 @@
       </div>
       {#if goal.dailyGoalCount > 0}
         <Stats 
-          bind:this={statsChildRef}
+          {plugin}
           {path}
           dailyColor={dGColor}
-          {heatMapData}
           data={linkedChartData}></Stats>
       {/if}
     {/if}

--- a/src/goal/goal.svelte
+++ b/src/goal/goal.svelte
@@ -144,14 +144,14 @@
           <text class="note-goal-text" stroke-width="0" x="100" y="140" id="svg_8" font-size="16" text-anchor="middle" xml:space="preserve">{getWordsText(goal)}</text>
         </svg>
         <GoalSummary bind:this={summaryChildRef} goal={goal} percent={percent} dailyPercent={dailyPercent} color={gColor} dailyColor={dGColor} />
+        {#if goal.dailyGoalCount > 0}
+          <Stats 
+            {plugin}
+            {path}
+            dailyColor={dGColor}
+            data={linkedChartData}></Stats>
+        {/if}
       </div>
-      {#if goal.dailyGoalCount > 0}
-        <Stats 
-          {plugin}
-          {path}
-          dailyColor={dGColor}
-          data={linkedChartData}></Stats>
-      {/if}
     {/if}
     {#if mode == 'simple'}
       <div class="writing-goals-simple-container" data-path="{path}">

--- a/src/goal/goal.svelte
+++ b/src/goal/goal.svelte
@@ -2,7 +2,7 @@
     import  GoalSummary from './goal-summary.svelte';
     import  Stats from '../stats/stats.svelte';
     import { onDestroy, onMount } from "svelte";
-	  import { dailyGoalColor, goalColor, goalHistory, noteGoals, showGoalMessage } from '../stores/goal-store';
+	  import { dailyGoalColor, goalColor, noteGoals } from '../stores/goal-store';
 	  import type { NoteGoal, Notes } from '../note-goal';
 	  import type { App } from 'obsidian';
 	  import type WritingGoals from '../main';
@@ -143,7 +143,7 @@
           <text class="note-goal-text" stroke-width="0" x="100" y="100" id="svg_4" font-size="40" text-anchor="middle" xml:space="preserve" font-weight="bold">{getWordCount(goal)}</text>
           <text class="note-goal-text" stroke-width="0" x="100" y="140" id="svg_8" font-size="16" text-anchor="middle" xml:space="preserve">{getWordsText(goal)}</text>
         </svg>
-        <GoalSummary bind:this={summaryChildRef} goal={goal} percent={percent} dailyPercent={dailyPercent} color={gColor} dailyColor={dGColor} />
+        <GoalSummary goal={goal} percent={percent} dailyPercent={dailyPercent} color={gColor} dailyColor={dGColor} />
         {#if goal.dailyGoalCount > 0}
           <Stats 
             {plugin}

--- a/src/goal/goal.svelte
+++ b/src/goal/goal.svelte
@@ -1,17 +1,23 @@
 <script lang="ts">
     import  GoalSummary from './goal-summary.svelte';
+    import  Stats from '../stats/stats.svelte';
     import { onDestroy, onMount } from "svelte";
 	  import { dailyGoalColor, goalColor, noteGoals, showGoalMessage } from '../stores/goal-store';
 	  import type { NoteGoal, Notes } from '../note-goal';
 	  import type { App } from 'obsidian';
-	import type WritingGoals from '../main';
+	  import type WritingGoals from '../main';
+	  import type { HistoryStatsItem } from '../goal-history/history';
     export let mode: string;
     export let path: string;
     export let color: string;
     export let dailyColor: string;
     export let plugin: WritingGoals;
     export let app: App;
+    export let heatMapData: HistoryStatsItem[];
+    export let linkedChartData: any;
 
+    let statsChildRef;
+    let summaryChildRef;
     let goals: Notes;
     let goal: NoteGoal;
     let percent: number = 0;
@@ -52,6 +58,15 @@
     onDestroy(unsubNoteGoals);
     onDestroy(unsubGoalColor);
     onDestroy(unsubDailyGoalColor);
+
+    onDestroy(() => {
+      if(statsChildRef) {
+        statsChildRef.$destroy();
+      }
+      if(summaryChildRef) {
+        summaryChildRef.$destroy();
+      }
+    })
     
     function updateGoal() {
       goal = goals[path];      
@@ -131,8 +146,16 @@
           <text class="note-goal-text" stroke-width="0" x="100" y="100" id="svg_4" font-size="40" text-anchor="middle" xml:space="preserve" font-weight="bold">{getWordCount(goal)}</text>
           <text class="note-goal-text" stroke-width="0" x="100" y="140" id="svg_8" font-size="16" text-anchor="middle" xml:space="preserve">{getWordsText(goal)}</text>
         </svg>
-        <GoalSummary goal={goal} percent={percent} dailyPercent={dailyPercent} gColor={gColor} dGColor={dGColor} />
+        <GoalSummary bind:this={summaryChildRef} goal={goal} percent={percent} dailyPercent={dailyPercent} color={gColor} dailyColor={dGColor} />
       </div>
+      {#if goal.dailyGoalCount > 0}
+        <Stats 
+          bind:this={statsChildRef}
+          {path}
+          dailyColor={dGColor}
+          {heatMapData}
+          data={linkedChartData}></Stats>
+      {/if}
     {/if}
     {#if mode == 'simple'}
       <div class="writing-goals-simple-container" data-path="{path}">

--- a/src/goal/goal.svelte
+++ b/src/goal/goal.svelte
@@ -148,6 +148,7 @@
           <Stats 
             {plugin}
             {path}
+            showProgress={plugin.settings.showProgressChart}
             dailyColor={dGColor}
             data={linkedChartData}></Stats>
         {/if}

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ import { WritingGoalsSettingsTab } from './settings/settings-tab';
 import { SettingsHelper } from './settings/settings-helper';
 import { NoteGoalHelper, Notes } from './note-goal';
 import { ObsidianFileHelper } from './IO/obsidian-file';
-import { noteGoals } from './stores/goal-store';
+import { goalHistory, noteGoals } from './stores/goal-store';
 import GoalTargetModal from './modals/goal-target-modal';
 import GoalModal from './modals/goal-modal';
 import { FileLabels } from './goal/file-labels';
@@ -248,6 +248,7 @@ export default class WritingGoals extends Plugin {
         notes[folderGoal.path] = goal;
       }
       noteGoals.set(notes);
+      goalHistory.set(await this.goalHistoryHelper.loadHistory());
       if(requiresGoalLabelUpdate){
         await this.fileLabels.initFileLabels(pathForLabel);
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,12 +40,12 @@ export default class WritingGoals extends Plugin {
     this.setupCommands();
     this.registerView(
       VIEW_TYPE_GOAL,
-      (leaf) => this.goalView = new GoalView(leaf, this)
+      (leaf) => this.goalView = new GoalView(leaf, this, this.goalHistoryHelper)
     );
-    this.registerView(
-      VIEW_TYPE_STATS,
-      (leaf) => this.statsView = new StatsView(leaf, this, this.goalHistoryHelper)
-    );
+    // this.registerView(
+    //   VIEW_TYPE_STATS,
+    //   (leaf) => this.statsView = new StatsView(leaf, this, this.goalHistoryHelper)
+    // );
     this.addSettingTab(new WritingGoalsSettingsTab(this.app, this));
     this.setupEvents();
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -42,10 +42,6 @@ export default class WritingGoals extends Plugin {
       VIEW_TYPE_GOAL,
       (leaf) => this.goalView = new GoalView(leaf, this, this.goalHistoryHelper)
     );
-    // this.registerView(
-    //   VIEW_TYPE_STATS,
-    //   (leaf) => this.statsView = new StatsView(leaf, this, this.goalHistoryHelper)
-    // );
     this.addSettingTab(new WritingGoalsSettingsTab(this.app, this));
     this.setupEvents();
     }
@@ -79,20 +75,7 @@ export default class WritingGoals extends Plugin {
           new GoalTargetModal(this.app, new GoalModal(this.app, this.settings, this.goalHistoryHelper), this).open();
         },
         hotkeys: []
-      });  
-
-      this.addCommand({
-        id: 'app:writing-goal-stats',
-        name: 'View writing goal stats',
-        callback: async () => {
-          const statsLeaf = await this.app.workspace.getRightLeaf(false);
-            await statsLeaf.setViewState({
-              type: VIEW_TYPE_STATS,
-              active: true
-            });
-        },
-        hotkeys: []
-      }); 
+      });   
     }
 
     setupEvents() {

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import {
 } from 'obsidian';
 
 import { WritingGoalsSettings } from './settings/settings';
-import { GOAL_ICON, REMOVE_GOAL_ICON, VIEW_TYPE_GOAL } from './constants';
+import { GOAL_ICON, REMOVE_GOAL_ICON, VIEW_TYPE_GOAL, VIEW_TYPE_STATS } from './constants';
 import GoalView from './goal/goal-view';
 import { WritingGoalsSettingsTab } from './settings/settings-tab';
 import { SettingsHelper } from './settings/settings-helper';
@@ -18,10 +18,12 @@ import GoalTargetModal from './modals/goal-target-modal';
 import GoalModal from './modals/goal-modal';
 import { FileLabels } from './goal/file-labels';
 import { GoalHistoryHelper } from './goal-history/history';
+import StatsView from './stats/stats-view';
 
 export default class WritingGoals extends Plugin {
   settings: WritingGoalsSettings = new WritingGoalsSettings;
   goalView: GoalView | undefined;
+  statsView: StatsView | undefined;
   fileLabels: FileLabels;
   fileHelper: ObsidianFileHelper = new ObsidianFileHelper(this.settings);
   goalHistoryHelper: GoalHistoryHelper;
@@ -39,6 +41,10 @@ export default class WritingGoals extends Plugin {
     this.registerView(
       VIEW_TYPE_GOAL,
       (leaf) => this.goalView = new GoalView(leaf, this)
+    );
+    this.registerView(
+      VIEW_TYPE_STATS,
+      (leaf) => this.statsView = new StatsView(leaf, this, this.goalHistoryHelper)
     );
     this.addSettingTab(new WritingGoalsSettingsTab(this.app, this));
     this.setupEvents();
@@ -74,6 +80,19 @@ export default class WritingGoals extends Plugin {
         },
         hotkeys: []
       });  
+
+      this.addCommand({
+        id: 'app:writing-goal-stats',
+        name: 'View writing goal stats',
+        callback: async () => {
+          const statsLeaf = await this.app.workspace.getRightLeaf(false);
+            await statsLeaf.setViewState({
+              type: VIEW_TYPE_STATS,
+              active: true
+            });
+        },
+        hotkeys: []
+      }); 
     }
 
     setupEvents() {

--- a/src/settings/settings-tab.ts
+++ b/src/settings/settings-tab.ts
@@ -5,7 +5,7 @@ import {
 } from 'obsidian';
 import type WritingGoals from '../main';
 import { FileLabels } from '../goal/file-labels';
-import { dailyGoalColor, goalColor, showGoalMessage } from '../stores/goal-store';
+import { dailyGoalColor, goalColor, showGoalMessage, showProgressChart } from '../stores/goal-store';
 import { DAILY_GOAL_BAR_COLOR, DAILY_GOAL_FRONTMATTER_KEY, GOAL_BAR_COLOR, GOAL_FRONTMATTER_KEY, VIEW_TYPE_GOAL } from '../constants';
   
   export class WritingGoalsSettingsTab extends PluginSettingTab {
@@ -38,7 +38,7 @@ import { DAILY_GOAL_BAR_COLOR, DAILY_GOAL_FRONTMATTER_KEY, GOAL_BAR_COLOR, GOAL_
 
       new Setting(containerEl)
         .setName('Display goal message')
-        .setDesc('Display a message below the progress including the current goal')
+        .setDesc('Display a summary message below the progress for the current goal')
         .addToggle(toggle => 
           toggle
             .setValue(this.plugin.settings.showGoalMessage)
@@ -46,6 +46,18 @@ import { DAILY_GOAL_BAR_COLOR, DAILY_GOAL_FRONTMATTER_KEY, GOAL_BAR_COLOR, GOAL_
               this.plugin.settings.showGoalMessage = value;
               await this.plugin.saveData(this.plugin.settings);
               showGoalMessage.set(value);
+            }));
+
+      new Setting(containerEl)
+        .setName('Display daily goal stas')
+        .setDesc('Display a bar chart for goal history below the progress for the current goal')
+        .addToggle(toggle => 
+          toggle
+            .setValue(this.plugin.settings.showProgressChart)
+            .onChange(async (value:boolean) => {
+              this.plugin.settings.showProgressChart = value;
+              await this.plugin.saveData(this.plugin.settings);
+              showProgressChart.set(value);
             }));
 
       new Setting(containerEl)

--- a/src/settings/settings.ts
+++ b/src/settings/settings.ts
@@ -12,6 +12,7 @@ export class WritingGoalsSettings {
   customGoalFrontmatterKey: string = GOAL_FRONTMATTER_KEY;
   customDailyGoalFrontmatterKey: string = DAILY_GOAL_FRONTMATTER_KEY;
   showSingleGoalView: boolean = false;
+  showProgressChart: boolean = false;
   excludeComments: boolean = true;
   allowNegativeGoalProgress: boolean= false;
   customGoalBarColor: string = GOAL_BAR_COLOR;

--- a/src/stats/stats-view.ts
+++ b/src/stats/stats-view.ts
@@ -6,6 +6,7 @@ import { ObsidianFileHelper } from '../IO/obsidian-file';
 import type WritingGoals from '../main';
 import GoalModal from '../modals/goal-modal';
 import type { GoalHistoryHelper, HistoryStatsItem } from '../goal-history/history';
+import moment from 'moment';
 
 
 export default class StatsView extends ItemView {
@@ -58,7 +59,7 @@ export default class StatsView extends ItemView {
             target: (this as any).contentEl,
             props: {
                 path: this.path,
-                heatmapData: heatmapData,
+                heatMapData: heatmapData,
                 data: linkedListData,
                 rootEl: this.containerEl
             },
@@ -66,8 +67,7 @@ export default class StatsView extends ItemView {
     }
 
     getLinkedChartData(data: HistoryStatsItem[]){
-        const result = Object.fromEntries(data.map(d => [d.date, d.value]));
-        console.log(result);
+        const result = Object.fromEntries(data.filter(d => d.value > 0).map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.value]));
         return result;
     }
 }

--- a/src/stats/stats-view.ts
+++ b/src/stats/stats-view.ts
@@ -1,0 +1,75 @@
+import { ItemView, WorkspaceLeaf } from 'obsidian';
+import Stats from './stats.svelte';
+import type { WritingGoalsSettings } from '../settings/settings';
+import { GOAL_ICON, VIEW_TYPE_GOAL, VIEW_TYPE_STATS } from '../constants';
+import { ObsidianFileHelper } from '../IO/obsidian-file';
+import type WritingGoals from '../main';
+import GoalModal from '../modals/goal-modal';
+import type { GoalHistoryHelper, HistoryStatsItem } from '../goal-history/history';
+
+
+export default class StatsView extends ItemView {
+   
+    fileHelper: ObsidianFileHelper;
+    settings: WritingGoalsSettings;
+    historyHelper: GoalHistoryHelper
+    path:string;
+    plugin: WritingGoals;
+    stats: any;
+
+    constructor(leaf: WorkspaceLeaf, plugin: WritingGoals, historyHelper: GoalHistoryHelper){
+        super(leaf);
+        this.plugin = plugin;
+        this.fileHelper = new ObsidianFileHelper(this.plugin.settings);
+        this.historyHelper = historyHelper;
+    }
+
+    getViewType(): string {
+        return VIEW_TYPE_STATS;
+    }
+
+    getDisplayText(): string {
+        return 'Writing goal stats';
+    }
+
+    getIcon() {
+        return GOAL_ICON;
+    }
+    
+    onload(): void {
+        
+    }
+
+    async onOpen() {
+        this.setStats();
+    }
+
+    async onClose() {
+
+    }
+
+    async setStats() {
+        if(this.stats != null) {
+            this.stats.$destroy();
+        }
+        const heatmapData = await this.historyHelper.getStats();
+        const linkedListData = this.getLinkedChartData(heatmapData);
+        this.stats = new Stats({
+            target: (this as any).contentEl,
+            props: {
+                path: this.path,
+                heatmapData: heatmapData,
+                data: linkedListData,
+                rootEl: this.containerEl
+            },
+        });    
+    }
+
+    getLinkedChartData(data: HistoryStatsItem[]){
+        const result = Object.fromEntries(data.map(d => [d.date, d.value]));
+        console.log(result);
+        return result;
+    }
+}
+
+

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { onMount } from "svelte";
-    import SvelteHeatmap from 'svelte-heatmap';
+    import SvelteHeatmap from "svelte-heatmap";
     import { LinkedChart, LinkedLabel, LinkedValue} from "svelte-tiny-linked-charts"
 	  import type { HistoryStatsItem } from "../goal-history/history";
     import { onDestroy } from 'svelte';
@@ -77,6 +77,7 @@
   width={250}
   height={80}
   valuePosition="floating"
+  align="left"
   />
 
 

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import { LinkedChart, LinkedLabel, LinkedValue} from "svelte-tiny-linked-charts"
+    import { LinkedChart, LinkedLabel} from "svelte-tiny-linked-charts"
     import { goalHistory } from "../stores/goal-store";
     import { onDestroy, onMount } from "svelte";
 	import type WritingGoals from "../main";
 	import moment from "moment";
-	import type { GoalHistoryItem, HistoryStatsItem } from "../goal-history/history";
+	import type { GoalHistoryItem } from "../goal-history/history";
 
     export let path: string;
     export let plugin: WritingGoals;
@@ -39,13 +39,15 @@
 <div class="linked-chart-container">
   <h3>Daily goal progress</h3>
   <div class="linked-chart-date-label">
-    <LinkedLabel linked="link-2"  />
+    <LinkedLabel linked={`${path}-link-2`} />
   </div>
     
   <LinkedChart 
+  uid={path}
   data={chartData}
-  linked="link-2"
+  linked={`${path}-link-2`}
   showValue
+  fadeOpacity={0.25}
   barMinWidth={6}
   valuePrepend=""
   valueAppend="words"  

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -1,19 +1,36 @@
 <script lang="ts">
+    import { onMount } from "svelte";
     import SvelteHeatmap from 'svelte-heatmap';
     import { LinkedChart, LinkedLabel, LinkedValue} from "svelte-tiny-linked-charts"
 	  import type { HistoryStatsItem } from "../goal-history/history";
+    import { onDestroy } from 'svelte';
+    import { dailyGoalColor } from '../stores/goal-store';
 
     // export let colors = ["#a1dab4", "#42b6c4", "#2c7fb9", "#263494"];
-    export let textColor = "#dadada";
-    export let emptyColor = "#362627";
-    export let type = "monthly";
-    export let cellRadius = 2;
-    export let heatmapData: HistoryStatsItem[];
+    // export let textColor = "#dadada";
+    // export let emptyColor = "#362627";
+    // export let type = "monthly";
+    // export let cellRadius = 2;
+    export let path: string;
+    export let heatMapData: HistoryStatsItem[];
     export let data: any;
+    export let dailyColor: string;
+
+    let dGColor: string;
     
+    onMount(() => {
+      dGColor = dailyColor;
+    })
+
+    const unsubDailyGoalColor = dailyGoalColor.subscribe(val => {
+      dGColor = val
+    });
+
+    onDestroy(unsubDailyGoalColor);
+
     let heatmap:SvelteHeatmap
-    let startDate = heatmapData[0].date;
-    let endDate = heatmapData[heatmapData.length - 1].date;
+    // let startDate = heatmapData[0].date;
+    // let endDate = heatmapData[heatmapData.length - 1].date;
     let monthlabel = [
     "",
     "Feb",
@@ -31,7 +48,7 @@
     
 </script>
 
-<div style="max-width: 500px">
+<!-- <div style="max-width: 500px">
   <SvelteHeatmap
     data={heatmapData}
     view={type}
@@ -43,14 +60,23 @@
     {emptyColor}
     {cellRadius}
   />
-</div>
+</div> -->
 
-<LinkedLabel linked="link-2" />
+
+<div class="linked-chart-date-lable" style="position: relative; margin-bottom: 25px">
+  <LinkedLabel linked="link-2"  />
+</div>
 
 <LinkedChart 
   { data } 
   linked="link-2"
   showValue
-  valueDefault="Empty label"
   valuePrepend=""
-  valueAppend="words"  />
+  valueAppend="words"  
+  fill="{dGColor}"
+  width={250}
+  height={80}
+  valuePosition="floating"
+  />
+
+

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -65,7 +65,7 @@
 
 <div class="linked-chart-container">
   <h3>Daily goal progress</h3>
-  <div class="linked-chart-date-lable" style="position: relative; margin-bottom: 25px">
+  <div class="linked-chart-date-label">
     <LinkedLabel linked="link-2"  />
   </div>
 
@@ -76,8 +76,7 @@
     valuePrepend=""
     valueAppend="words"  
     fill="{dailyColor}"
-    width={250}
-    height={80}
+    height={60}
     valuePosition="floating"
     align="left"
     />

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -10,7 +10,6 @@
     export let plugin: WritingGoals;
     export let data: any;
     export let dailyColor: string;
-
     let chartData:any;
 
     onMount(() => {
@@ -19,9 +18,14 @@
 
     const unsubHistory = goalHistory.subscribe(val => {
       if(val != null && val[path] != null){
+        const allowNegativeGoalProgress = plugin.settings.allowNegativeGoalProgress;
         const historyItems = val[path] as GoalHistoryItem[]
         console.log('tranform input from store', historyItems);
-        chartData = Object.fromEntries(historyItems.map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.endCount - d.startCount]));
+        chartData = Object.fromEntries(historyItems.map(d => {
+          const diff = d.endCount - d.startCount;
+          const count = allowNegativeGoalProgress || diff >= 0 ? diff : 0; 
+          return [moment(new Date(d.date)).format("ddd DD MMM YYYY"), count];
+        }));
         console.log('data for chart', chartData);
       }
     });
@@ -42,11 +46,13 @@
   data={chartData}
   linked="link-2"
   showValue
+  barMinWidth={6}
   valuePrepend=""
   valueAppend="words"  
   fill="{dailyColor}"
   valuePosition="floating"
   align="left"
+  transition={500}
   />
 </div>
 {/if}

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+    import SvelteHeatmap from 'svelte-heatmap';
+    import { LinkedChart, LinkedLabel, LinkedValue} from "svelte-tiny-linked-charts"
+	  import type { HistoryStatsItem } from "../goal-history/history";
+
+    // export let colors = ["#a1dab4", "#42b6c4", "#2c7fb9", "#263494"];
+    export let textColor = "#dadada";
+    export let emptyColor = "#362627";
+    export let type = "monthly";
+    export let cellRadius = 2;
+    export let heatmapData: HistoryStatsItem[];
+    export let data: any;
+    
+    let heatmap:SvelteHeatmap
+    let startDate = heatmapData[0].date;
+    let endDate = heatmapData[heatmapData.length - 1].date;
+    let monthlabel = [
+    "",
+    "Feb",
+    "Mar",
+    "Apr",
+    "May",
+    "Jun",
+    "Jul",
+    "Aug",
+    "Sep",
+    "Oct",
+    "Nov",
+    "Dec",
+  ];
+    
+</script>
+
+<div style="max-width: 500px">
+  <SvelteHeatmap
+    data={heatmapData}
+    view={type}
+    {startDate}
+    {endDate}
+    monthLabels={monthlabel}
+    allowOverflow="true"
+    fontColor={textColor}
+    {emptyColor}
+    {cellRadius}
+  />
+</div>
+
+<LinkedLabel linked="link-2" />
+
+<LinkedChart 
+  { data } 
+  linked="link-2"
+  showValue
+  valueDefault="Empty label"
+  valuePrepend=""
+  valueAppend="words"  />

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -1,19 +1,26 @@
 <script lang="ts">
     import { LinkedChart, LinkedLabel} from "svelte-tiny-linked-charts"
-    import { goalHistory } from "../stores/goal-store";
+    import { goalHistory, showProgressChart } from "../stores/goal-store";
     import { onDestroy, onMount } from "svelte";
-	import type WritingGoals from "../main";
-	import moment from "moment";
-	import type { GoalHistoryItem } from "../goal-history/history";
+    import type WritingGoals from "../main";
+    import moment from "moment";
+    import type { GoalHistoryItem } from "../goal-history/history";
 
     export let path: string;
     export let plugin: WritingGoals;
     export let data: any;
     export let dailyColor: string;
+    export let showProgress: boolean;
     let chartData:any;
+    let showChart: boolean;
 
     onMount(() => {
       chartData = data;
+      showChart = showProgress;
+    });
+
+    const unsubNShowProgressChart = showProgressChart.subscribe(val => {
+        showChart = val;
     });
 
     const unsubHistory = goalHistory.subscribe(val => {
@@ -35,7 +42,7 @@
 </script>
 
 
-{#if data != null}
+{#if data != null && showChart}
 <div class="linked-chart-container">
   <h3>Daily goal progress</h3>
   <div class="linked-chart-date-label">

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -1,29 +1,52 @@
 <script lang="ts">
     import { LinkedChart, LinkedLabel, LinkedValue} from "svelte-tiny-linked-charts"
-	  import type { HistoryStatsItem } from "../goal-history/history";
+    import { goalHistory } from "../stores/goal-store";
+    import { onDestroy, onMount } from "svelte";
+	import type WritingGoals from "../main";
+	import moment from "moment";
+	import type { GoalHistoryItem, HistoryStatsItem } from "../goal-history/history";
 
     export let path: string;
+    export let plugin: WritingGoals;
     export let data: any;
     export let dailyColor: string;
+
+    let chartData:any;
+
+    onMount(() => {
+      chartData = data;
+    });
+
+    const unsubHistory = goalHistory.subscribe(val => {
+      if(val != null && val[path] != null){
+        const historyItems = val[path] as GoalHistoryItem[]
+        console.log('tranform input from store', historyItems);
+        chartData = Object.fromEntries(historyItems.map(d => [moment(new Date(d.date)).format("ddd DD MMM YYYY"), d.endCount - d.startCount]));
+        console.log('data for chart', chartData);
+      }
+    });
+
+    onDestroy(unsubHistory);
     
 </script>
 
 
+{#if data != null}
 <div class="linked-chart-container">
   <h3>Daily goal progress</h3>
   <div class="linked-chart-date-label">
     <LinkedLabel linked="link-2"  />
   </div>
-
+    
   <LinkedChart 
-    { data } 
-    linked="link-2"
-    showValue
-    valuePrepend=""
-    valueAppend="words"  
-    fill="{dailyColor}"
-    height={60}
-    valuePosition="floating"
-    align="left"
-    />
+  data={chartData}
+  linked="link-2"
+  showValue
+  valuePrepend=""
+  valueAppend="words"  
+  fill="{dailyColor}"
+  valuePosition="floating"
+  align="left"
+  />
 </div>
+{/if}

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -48,7 +48,7 @@
   linked={`${path}-link-2`}
   showValue
   fadeOpacity={0.25}
-  barMinWidth={6}
+  barMinWidth={4}
   valuePrepend=""
   valueAppend="words"  
   fill="{dailyColor}"

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -1,66 +1,12 @@
 <script lang="ts">
-    import { onMount } from "svelte";
-    import SvelteHeatmap from "svelte-heatmap";
     import { LinkedChart, LinkedLabel, LinkedValue} from "svelte-tiny-linked-charts"
 	  import type { HistoryStatsItem } from "../goal-history/history";
-    import { onDestroy } from 'svelte';
-    import { dailyGoalColor } from '../stores/goal-store';
 
-    // export let colors = ["#a1dab4", "#42b6c4", "#2c7fb9", "#263494"];
-    // export let textColor = "#dadada";
-    // export let emptyColor = "#362627";
-    // export let type = "monthly";
-    // export let cellRadius = 2;
     export let path: string;
-    export let heatMapData: HistoryStatsItem[];
     export let data: any;
     export let dailyColor: string;
-
-    let dGColor: string;
-    
-    // onMount(() => {
-    //   dGColor = dailyColor;
-    // })
-
-    // const unsubDailyGoalColor = dailyGoalColor.subscribe(val => {
-    //   dGColor = val
-    // });
-
-    // onDestroy(unsubDailyGoalColor);
-
-    let heatmap:SvelteHeatmap
-    // let startDate = heatmapData[0].date;
-    // let endDate = heatmapData[heatmapData.length - 1].date;
-    let monthlabel = [
-    "",
-    "Feb",
-    "Mar",
-    "Apr",
-    "May",
-    "Jun",
-    "Jul",
-    "Aug",
-    "Sep",
-    "Oct",
-    "Nov",
-    "Dec",
-  ];
     
 </script>
-
-<!-- <div style="max-width: 500px">
-  <SvelteHeatmap
-    data={heatmapData}
-    view={type}
-    {startDate}
-    {endDate}
-    monthLabels={monthlabel}
-    allowOverflow="true"
-    fontColor={textColor}
-    {emptyColor}
-    {cellRadius}
-  />
-</div> -->
 
 
 <div class="linked-chart-container">

--- a/src/stats/stats.svelte
+++ b/src/stats/stats.svelte
@@ -18,15 +18,15 @@
 
     let dGColor: string;
     
-    onMount(() => {
-      dGColor = dailyColor;
-    })
+    // onMount(() => {
+    //   dGColor = dailyColor;
+    // })
 
-    const unsubDailyGoalColor = dailyGoalColor.subscribe(val => {
-      dGColor = val
-    });
+    // const unsubDailyGoalColor = dailyGoalColor.subscribe(val => {
+    //   dGColor = val
+    // });
 
-    onDestroy(unsubDailyGoalColor);
+    // onDestroy(unsubDailyGoalColor);
 
     let heatmap:SvelteHeatmap
     // let startDate = heatmapData[0].date;
@@ -63,21 +63,22 @@
 </div> -->
 
 
-<div class="linked-chart-date-lable" style="position: relative; margin-bottom: 25px">
-  <LinkedLabel linked="link-2"  />
+<div class="linked-chart-container">
+  <h3>Daily goal progress</h3>
+  <div class="linked-chart-date-lable" style="position: relative; margin-bottom: 25px">
+    <LinkedLabel linked="link-2"  />
+  </div>
+
+  <LinkedChart 
+    { data } 
+    linked="link-2"
+    showValue
+    valuePrepend=""
+    valueAppend="words"  
+    fill="{dailyColor}"
+    width={250}
+    height={80}
+    valuePosition="floating"
+    align="left"
+    />
 </div>
-
-<LinkedChart 
-  { data } 
-  linked="link-2"
-  showValue
-  valuePrepend=""
-  valueAppend="words"  
-  fill="{dGColor}"
-  width={250}
-  height={80}
-  valuePosition="floating"
-  align="left"
-  />
-
-

--- a/src/stores/goal-store.ts
+++ b/src/stores/goal-store.ts
@@ -5,5 +5,6 @@ import { GoalHistory } from '../goal-history/history';
 export const noteGoals = writable(new Notes());
 export const goalHistory = writable(new GoalHistory());
 export const showGoalMessage = writable(true);
+export const showProgressChart = writable(false);
 export const goalColor = writable("");
 export const dailyGoalColor = writable("");

--- a/src/stores/goal-store.ts
+++ b/src/stores/goal-store.ts
@@ -1,7 +1,9 @@
 import { writable } from 'svelte/store';
 import { Notes } from '../note-goal';
+import { GoalHistory } from '../goal-history/history';
 
 export const noteGoals = writable(new Notes());
+export const goalHistory = writable(new GoalHistory());
 export const showGoalMessage = writable(true);
 export const goalColor = writable("");
 export const dailyGoalColor = writable("");

--- a/styles.css
+++ b/styles.css
@@ -84,14 +84,20 @@
 
 .linked-chart-container {
     background-color: var(--background-primary);
-    border-radius: 10px;
-    max-width: 450px;
+    border-radius: 8px;
+    max-width: 550px;
     margin-top: 24px;
     padding: 4px 20px 32px 20px;
+    position: relative;
+}
+
+.linked-chart-date-label {
     text-align: center;
 }
 
 .linked-chart-container h3, .linked-chart-container h4 {
     color: var(--color-text-title);
+    font-size: 1em;
+    margin: 4px 0;
     text-align: center;
 }

--- a/styles.css
+++ b/styles.css
@@ -101,3 +101,7 @@
     margin: 4px 0;
     text-align: center;
 }
+
+.linked-chart-container rect {
+    transition: y 1s linear;
+}

--- a/styles.css
+++ b/styles.css
@@ -78,3 +78,20 @@
     fill: var(--background-primary);
     max-width: 50px;
 }
+
+
+/* STATS */
+
+.linked-chart-container {
+    background-color: var(--background-primary);
+    border-radius: 10px;
+    max-width: 450px;
+    margin-top: 24px;
+    padding: 4px 20px 32px 20px;
+    text-align: center;
+}
+
+.linked-chart-container h3, .linked-chart-container h4 {
+    color: var(--color-text-title);
+    text-align: center;
+}

--- a/styles.css
+++ b/styles.css
@@ -55,11 +55,11 @@
 }
 
 .wg-bar, .wg-simple .wg-bar {
-    transition: stroke-dashoffset 1s linear;
+    transition: stroke-dashoffset 0.5s linear;
 }
 
 .wg-daily-bar, .wg-goals-simple .wg-daily-bar {
-    transition: stroke-dashoffset 1s linear;
+    transition: stroke-dashoffset 0.5s linear;
 }
 
 .wg-background, .wg-daily-background {
@@ -85,10 +85,15 @@
 .linked-chart-container {
     background-color: var(--background-primary);
     border-radius: 8px;
+    height: 120px;
     max-width: 550px;
-    margin-top: 24px;
+    margin-top: 8px;
     padding: 4px 20px 32px 20px;
     position: relative;
+}
+
+.linked-chart-container svg {
+    width: 100%;
 }
 
 .linked-chart-date-label {
@@ -100,8 +105,4 @@
     font-size: 1em;
     margin: 4px 0;
     text-align: center;
-}
-
-.linked-chart-container rect {
-    transition: y 1s linear;
 }


### PR DESCRIPTION
Adds daily goal stats feature:
- Setting to enable goal stats displayed below current goal progress (disabled by default)
- Investigated using [Heatmap](https://github.com/scottbedard/svelte-heatmap) but preferred using [Tiny Linked Charts](https://mitcheljager.github.io/svelte-tiny-linked-charts).
- Chart displays a bar chart for the words written on each day.
- Chart should update in real-time with [one known issue](https://github.com/Mitcheljager/svelte-tiny-linked-charts/issues/10).
- Setting to "Allow negative goal progress" is respected in displaying negative word counts in the chart.